### PR TITLE
Sd ia estimate next purchase

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -49,6 +49,8 @@ const AddItem = () => {
         token,
         frequency,
         lastPurchasedDate,
+        numberOfPurchases,
+        previousEstimate,
         isPurchased: false,
       };
 

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -49,10 +49,10 @@ const AddItem = () => {
         token,
         frequency,
         lastPurchasedDate,
-        numberOfPurchases,
-        previousEstimate,
-        daysUntilPurchase,
         isPurchased: false,
+        numberOfPurchases: 0,
+        previousEstimate: null,
+        daysUntilPurchase: null,
       };
 
       await firestore.collection('items').add(itemTemplate);

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -51,7 +51,6 @@ const AddItem = () => {
         lastPurchasedDate,
         isPurchased: false,
         numberOfPurchases: 0,
-        previousEstimate: null,
         daysUntilPurchase: null,
       };
 

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -51,6 +51,7 @@ const AddItem = () => {
         lastPurchasedDate,
         numberOfPurchases,
         previousEstimate,
+        daysUntilPurchase,
         isPurchased: false,
       };
 

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -65,7 +65,7 @@ const AddItem = () => {
     if (e.target.name === 'item') {
       setItem(e.target.value);
     } else if (e.target.name === 'frequency') {
-      setFrequency(e.target.value);
+      setFrequency(Number(e.target.value));
     }
   };
 

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -37,7 +37,7 @@ const SingleItem = (props) => {
     }
   });
 
-  let latestInterval = frequency;
+  let latestInterval = Number(frequency);
 
   if (lastPurchasedDate) {
     latestInterval = Math.round((Date.now() - lastPurchasedDate) / mlsPerDay);

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -59,7 +59,9 @@ const SingleItem = (props) => {
         numberOfPurchases: !isPurchased
           ? numberOfPurchases + 1
           : numberOfPurchases,
-        daysUntilPurchase: nextPurchaseDate,
+        daysUntilPurchase: e.target.checked
+          ? nextPurchaseDate
+          : daysUntilPurchase,
       });
   };
 

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -23,8 +23,6 @@ const SingleItem = (props) => {
   setInterval(() => {
     const todaysDate = Date.now();
     const yesterday = todaysDate - 24 * 60 * 60 * 1000;
-    console.log('lastPurchasedDate', lastPurchasedDate);
-    console.log('yesterday', yesterday);
     if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -60,7 +60,7 @@ const SingleItem = (props) => {
         isPurchased: !isPurchased,
         lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
         numberOfPurchases: !isPurchased
-          ? numberOfPurchases + 1
+          ? numberOfPurchases + 1 || 1
           : numberOfPurchases,
         daysUntilPurchase: nextPurchaseDate || daysUntilPurchase,
       });

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { firestore } from '../lib/firebase';
+import calculateEstimate from '../lib/estimates';
 
 const SingleItem = (props) => {
   const {
@@ -13,6 +14,8 @@ const SingleItem = (props) => {
     previousEstimate,
     daysUntilPurchase,
   } = props;
+
+  const mlsPerDay = 86400000;
 
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).set({
@@ -33,6 +36,7 @@ const SingleItem = (props) => {
   }, 60000);
 
   useEffect(() => {
+    console.log(name, frequency);
     const todaysDate = Date.now();
     const yesterday = todaysDate - 24 * 60 * 60 * 1000;
     if (lastPurchasedDate < yesterday) {
@@ -40,18 +44,36 @@ const SingleItem = (props) => {
     }
   });
 
+  let latestInterval = 0;
+
+  if (lastPurchasedDate) {
+    latestInterval = Math.round((Date.now() - lastPurchasedDate) / mlsPerDay);
+  }
+
   const handleChange = async (e) => {
-    // maybe calculate estimate here
+    let nextPurchaseDate = calculateEstimate(
+      previousEstimate,
+      latestInterval,
+      numberOfPurchases + 1,
+    );
+
     await firestore
       .collection('items')
       .doc(id)
-      .set({
+      .update({
+        // tried .update() instead of .set()
         isPurchased: !isPurchased,
         lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
-        token,
-        name,
-        frequency,
+        numberOfPurchases: numberOfPurchases + 1,
+        daysUntilPurchase: nextPurchaseDate,
       });
+    // .set({
+    //     isPurchased: !isPurchased,
+    //     lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
+    //     token,
+    //     name,
+    //     frequency,
+    //   });
   };
 
   return (

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -26,7 +26,7 @@ const SingleItem = (props) => {
     if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }
-  }, 10000);
+  }, 60000);
 
   useEffect(() => {
     const todaysDate = Date.now();

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -12,7 +12,7 @@ const SingleItem = (props) => {
     daysUntilPurchase,
   } = props;
 
-  const mlsPerDay = 86400000;
+  const mlsPerDay = 24 * 60 * 60 * 1000;
 
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).update({
@@ -22,7 +22,7 @@ const SingleItem = (props) => {
 
   setInterval(() => {
     const todaysDate = Date.now();
-    const yesterday = todaysDate - 24 * 60 * 60 * 1000;
+    const yesterday = todaysDate - mlsPerDay;
     if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }
@@ -30,7 +30,7 @@ const SingleItem = (props) => {
 
   useEffect(() => {
     const todaysDate = Date.now();
-    const yesterday = todaysDate - 24 * 60 * 60 * 1000;
+    const yesterday = todaysDate - mlsPerDay;
     if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -2,7 +2,17 @@ import React, { useEffect } from 'react';
 import { firestore } from '../lib/firebase';
 
 const SingleItem = (props) => {
-  const { name, isPurchased, id, token, frequency, lastPurchasedDate } = props;
+  const {
+    name,
+    isPurchased,
+    id,
+    token,
+    frequency,
+    lastPurchasedDate,
+    numberOfPurchases,
+    previousEstimate,
+    daysUntilPurchase,
+  } = props;
 
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).set({
@@ -32,7 +42,6 @@ const SingleItem = (props) => {
 
   const handleChange = async (e) => {
     // maybe calculate estimate here
-    
     await firestore
       .collection('items')
       .doc(id)

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -7,6 +7,7 @@ const SingleItem = (props) => {
     name,
     isPurchased,
     id,
+    frequency,
     lastPurchasedDate,
     numberOfPurchases,
     daysUntilPurchase,
@@ -36,7 +37,7 @@ const SingleItem = (props) => {
     }
   });
 
-  let latestInterval = 0;
+  let latestInterval = frequency;
 
   if (lastPurchasedDate) {
     latestInterval = Math.round((Date.now() - lastPurchasedDate) / mlsPerDay);
@@ -55,7 +56,9 @@ const SingleItem = (props) => {
       .update({
         isPurchased: !isPurchased,
         lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
-        numberOfPurchases: numberOfPurchases + 1,
+        numberOfPurchases: !isPurchased
+          ? numberOfPurchases + 1
+          : numberOfPurchases,
         daysUntilPurchase: nextPurchaseDate,
       });
   };

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -44,11 +44,14 @@ const SingleItem = (props) => {
   }
 
   const handleChange = async (e) => {
-    let nextPurchaseDate = calculateEstimate(
-      daysUntilPurchase,
-      latestInterval,
-      numberOfPurchases + 1,
-    );
+    let nextPurchaseDate;
+    if (e.target.checked) {
+      nextPurchaseDate = calculateEstimate(
+        daysUntilPurchase,
+        latestInterval,
+        numberOfPurchases + 1,
+      );
+    }
 
     await firestore
       .collection('items')
@@ -59,9 +62,7 @@ const SingleItem = (props) => {
         numberOfPurchases: !isPurchased
           ? numberOfPurchases + 1
           : numberOfPurchases,
-        daysUntilPurchase: e.target.checked
-          ? nextPurchaseDate
-          : daysUntilPurchase,
+        daysUntilPurchase: nextPurchaseDate || daysUntilPurchase,
       });
   };
 

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -31,6 +31,8 @@ const SingleItem = (props) => {
   });
 
   const handleChange = async (e) => {
+    // maybe calculate estimate here
+    
     await firestore
       .collection('items')
       .doc(id)

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -7,11 +7,8 @@ const SingleItem = (props) => {
     name,
     isPurchased,
     id,
-    token,
-    frequency,
     lastPurchasedDate,
     numberOfPurchases,
-    previousEstimate,
     daysUntilPurchase,
   } = props;
 
@@ -20,13 +17,6 @@ const SingleItem = (props) => {
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).update({
       isPurchased: false,
-      // lastPurchasedDate,
-      // token,
-      // name,
-      // frequency,
-      // numberOfPurchases,
-      // previousEstimate,
-      // daysUntilPurchase,
     });
   };
 
@@ -65,19 +55,11 @@ const SingleItem = (props) => {
       .collection('items')
       .doc(id)
       .update({
-        // tried .update() instead of .set()
         isPurchased: !isPurchased,
         lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
         numberOfPurchases: numberOfPurchases + 1,
         daysUntilPurchase: nextPurchaseDate,
       });
-    // .set({
-    //     isPurchased: !isPurchased,
-    //     lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
-    //     token,
-    //     name,
-    //     frequency,
-    //   });
   };
 
   return (

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -18,28 +18,32 @@ const SingleItem = (props) => {
   const mlsPerDay = 86400000;
 
   const updateIsPurchased = async (id) => {
-    await firestore.collection('items').doc(id).set({
+    await firestore.collection('items').doc(id).update({
       isPurchased: false,
-      lastPurchasedDate,
-      token,
-      name,
-      frequency,
+      // lastPurchasedDate,
+      // token,
+      // name,
+      // frequency,
+      // numberOfPurchases,
+      // previousEstimate,
+      // daysUntilPurchase,
     });
   };
 
   setInterval(() => {
     const todaysDate = Date.now();
     const yesterday = todaysDate - 24 * 60 * 60 * 1000;
-    if (lastPurchasedDate < yesterday) {
+    console.log('lastPurchasedDate', lastPurchasedDate);
+    console.log('yesterday', yesterday);
+    if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }
-  }, 60000);
+  }, 10000);
 
   useEffect(() => {
-    console.log(name, frequency);
     const todaysDate = Date.now();
     const yesterday = todaysDate - 24 * 60 * 60 * 1000;
-    if (lastPurchasedDate < yesterday) {
+    if (lastPurchasedDate && lastPurchasedDate < yesterday) {
       updateIsPurchased(id);
     }
   });
@@ -52,7 +56,7 @@ const SingleItem = (props) => {
 
   const handleChange = async (e) => {
     let nextPurchaseDate = calculateEstimate(
-      previousEstimate,
+      daysUntilPurchase,
       latestInterval,
       numberOfPurchases + 1,
     );


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

- Added new variables to `itemTemplate`:  `numberofPurchases` and `daysUntilPurchase`
- `numberOfPurchases` is the number of times an item has been purchased. Any time an item is checked, this value increments by 1.
- `daysUntilPurchase` is the calculated result of the `calculateEstimate` function
- Declared a `latestInterval` initially set to `frequency`, which will be used inside the `calculateEstimate` function. `latestInterval` is the current date minus the previously purchased date, in the form of # of days.
- Used `calculateEstimate` inside the `handleChange` function 
- Stored milliseconds conversion into a variable `mlsPerDay`
- Changed firestore from `.set` to `.update` to save having to set variables each time

Thoughts We Had: 
- Should `frequency` be used when calculating the estimate?
- Not sure if the `daysUntilPurchase` updates accurately. Will need to calculate on our own to test it

UPDATE: 
- Used `frequency` as initial `latestInterval` value to be used in `calculateEstimate` function
- Added a condition inside the `handleChange` to check if the checkbox is checked before using the `calculateEstimate` function so that it doesn't update when the checkbox is both check _and_ unchecked
- `daysUntilPurchase` is now set to `nextPurchaseDate` _or_ `daysUntilPurchase` -- `daysUntilPurchase` so that it doesn't update when the box is unchecked

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

closes #10 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- [x] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database
- [x] The script at `/src/lib/estimates.js` should be used to calculate the next estimated purchase interval.

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="371" alt="Screen Shot 2021-08-10 at 9 01 33 PM" src="https://user-images.githubusercontent.com/60532744/128953939-aae87215-b3c0-4737-aff4-ccbaa9679577.png">

<!-- If UI feature, take provide screenshots -->

### After

Variables are initially declared when you first add an item: 
<img width="352" alt="Screen Shot 2021-08-10 at 9 02 14 PM" src="https://user-images.githubusercontent.com/60532744/128953988-3b1a06ce-7727-4f6d-abdf-855519bce54b.png">

After checking off an item as purchased:
<img width="404" alt="Screen Shot 2021-08-10 at 9 03 07 PM" src="https://user-images.githubusercontent.com/60532744/128954028-f766c077-717e-45d0-a1af-ec6ff1aa0ec0.png">

After an item has been purchased more than 2 times:
<img width="397" alt="Screen Shot 2021-08-10 at 9 04 22 PM" src="https://user-images.githubusercontent.com/60532744/128954121-5c42345b-e0ab-4ca4-968c-13b367e4bb96.png">

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

- Pull down branch `sd-ia-estimate-next-purchase`
- Add a new item
- Check off item to mark as purchased
- Change `lastPurchasedDate` of item in firestore to a date before the previous purchase
- Once item has reached over 2 purchases, the `daysUntilPurchase` should change

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

