### PR TITLE
Some small changes based on comments in sd-ia-estimate-next-purchase PR 👍 

### DIFF
--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -59,7 +59,9 @@ const SingleItem = (props) => {
         numberOfPurchases: !isPurchased
           ? numberOfPurchases + 1
           : numberOfPurchases,
-        daysUntilPurchase: nextPurchaseDate,
+        daysUntilPurchase: e.target.checked
+          ? nextPurchaseDate
+          : daysUntilPurchase,
       });
   };
 

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -7,6 +7,7 @@ const SingleItem = (props) => {
     name,
     isPurchased,
     id,
+    frequency,
     lastPurchasedDate,
     numberOfPurchases,
     daysUntilPurchase,
@@ -36,7 +37,7 @@ const SingleItem = (props) => {
     }
   });
 
-  let latestInterval = 0;
+  let latestInterval = frequency;
 
   if (lastPurchasedDate) {
     latestInterval = Math.round((Date.now() - lastPurchasedDate) / mlsPerDay);
@@ -55,7 +56,9 @@ const SingleItem = (props) => {
       .update({
         isPurchased: !isPurchased,
         lastPurchasedDate: !isPurchased ? Date.now() : lastPurchasedDate,
-        numberOfPurchases: numberOfPurchases + 1,
+        numberOfPurchases: !isPurchased
+          ? numberOfPurchases + 1
+          : numberOfPurchases,
         daysUntilPurchase: nextPurchaseDate,
       });
   };

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -44,11 +44,14 @@ const SingleItem = (props) => {
   }
 
   const handleChange = async (e) => {
-    let nextPurchaseDate = calculateEstimate(
-      daysUntilPurchase,
-      latestInterval,
-      numberOfPurchases + 1,
-    );
+    let nextPurchaseDate;
+    if (e.target.checked) {
+      nextPurchaseDate = calculateEstimate(
+        daysUntilPurchase,
+        latestInterval,
+        numberOfPurchases + 1,
+      );
+    }
 
     await firestore
       .collection('items')
@@ -59,9 +62,7 @@ const SingleItem = (props) => {
         numberOfPurchases: !isPurchased
           ? numberOfPurchases + 1
           : numberOfPurchases,
-        daysUntilPurchase: e.target.checked
-          ? nextPurchaseDate
-          : daysUntilPurchase,
+        daysUntilPurchase: nextPurchaseDate || daysUntilPurchase,
       });
   };
 


### PR DESCRIPTION
### Description

Made a couple small changes based on @ksiman14's comments on sd-ia-estimate-next-purchase PR.
- `numberOfPurchases` should only increment if item was previously not purchased and the user checks the box. Should not increment if box is unchecked
- Brought in `frequency` variable into `SingleItem` component through props
- Initialized `latestInterval` value as set to `frequency`

NOTE: I did notice that since we are using the `calculateEstimate` function inside a `handleChange`, the estimated next purchase is calculate both when the box is checked _and_ unchecked. So we may need to do something small to refactor.

If things changes are okay and we all agree, maybe we can merge this with the sd-ia-estimate-next-estimate branch before merging that branch to main.
