### PR TITLE
Hulya and Isa sorting items

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -50,7 +50,7 @@ const AddItem = () => {
         lastPurchasedDate: null,
         isPurchased: false,
         numberOfPurchases: 0,
-        daysUntilPurchase: null,
+        daysUntilPurchase: 0,
       };
 
       await firestore.collection('items').add(itemTemplate);

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -50,7 +50,9 @@ const AddItem = () => {
         lastPurchasedDate: null,
         isPurchased: false,
         numberOfPurchases: 0,
-        daysUntilPurchase: null,
+        // initialized value of daysUntilPurchase as frequency instead of null
+        // to assist with sorting for items that have not been purchased yet
+        daysUntilPurchase: frequency,
       };
 
       await firestore.collection('items').add(itemTemplate);

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -32,21 +32,6 @@ const ItemsList = () => {
     history.push('/add');
   };
 
-  // snapshot.docs.map((item) => {
-  //   if (item.data().daysUntilPurchase <= 7) {
-  //     return 'soon';
-  //   } else if (
-  //     item.data().daysUntilPurchase > 7 &&
-  //     item.data().daysUntilPurchase <= 30
-  //   ) {
-  //     return 'kindOfSoon';
-  //   } else if (item.data().daysUntilPurchase > 30) {
-  //     return 'notSoSoon';
-  //   } else {
-  //     return 'inactive';
-  //   }
-  // });
-
   return (
     <div>
       {loading && <>Loading</>}

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -14,6 +14,7 @@ const ItemsList = () => {
       .collection('items')
       .where('token', '==', token)
       .orderBy('daysUntilPurchase', 'asc'),
+    // .orderBy('name', 'asc'),
   );
 
   const removeToken = () => {
@@ -51,6 +52,12 @@ const ItemsList = () => {
               {snapshot.docs
                 .filter((doc) =>
                   doc.data().name.toLowerCase().includes(search.toLowerCase()),
+                )
+                .sort((a, b) =>
+                  a
+                    .data()
+                    .name.toLowerCase()
+                    .localeCompare(b.data().name.toLowerCase()),
                 )
                 .map((doc, index) => (
                   <SingleItem key={index} {...doc.data()} id={doc.id} />

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -13,8 +13,8 @@ const ItemsList = () => {
     firestore
       .collection('items')
       .where('token', '==', token)
-      .orderBy('daysUntilPurchase', 'asc'),
-    // .orderBy('name', 'asc'),
+      .orderBy('daysUntilPurchase', 'asc')
+      .orderBy('name', 'asc'),
   );
 
   const removeToken = () => {
@@ -52,12 +52,6 @@ const ItemsList = () => {
               {snapshot.docs
                 .filter((doc) =>
                   doc.data().name.toLowerCase().includes(search.toLowerCase()),
-                )
-                .sort((a, b) =>
-                  a
-                    .data()
-                    .name.toLowerCase()
-                    .localeCompare(b.data().name.toLowerCase()),
                 )
                 .map((doc, index) => (
                   <SingleItem key={index} {...doc.data()} id={doc.id} />

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -7,9 +7,14 @@ import { useState } from 'react';
 const ItemsList = () => {
   const token = localStorage.getItem('token');
   const [search, setSearch] = useState('');
+
   const [snapshot, loading, error] = useCollection(
-    firestore.collection('items').where('token', '==', token),
+    firestore
+      .collection('items')
+      .where('token', '==', token)
+      .orderBy('frequency'),
   );
+
   const history = useHistory();
 
   const removeToken = () => {

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -16,13 +16,6 @@ const ItemsList = () => {
       .orderBy('daysUntilPurchase', 'asc'),
   );
 
-  const styles = {
-    soon: 'green',
-    kindOfSoon: 'orange',
-    notSoSoon: 'red',
-    inactive: 'gray',
-  };
-
   const removeToken = () => {
     localStorage.removeItem('token');
     history.push('/');
@@ -59,48 +52,9 @@ const ItemsList = () => {
                 .filter((doc) =>
                   doc.data().name.toLowerCase().includes(search.toLowerCase()),
                 )
-                .map((doc, index) => {
-                  if (doc.data().daysUntilPurchase <= 7) {
-                    return (
-                      <SingleItem
-                        key={index}
-                        {...doc.data()}
-                        id={doc.id}
-                        styles={styles.soon}
-                      />
-                    );
-                  } else if (
-                    doc.data().daysUntilPurchase > 7 &&
-                    doc.data().daysUntilPurchase < 30
-                  ) {
-                    return (
-                      <SingleItem
-                        key={index}
-                        {...doc.data()}
-                        id={doc.id}
-                        styles={styles.kindOfSoon}
-                      />
-                    );
-                  } else if (doc.data().daysUntilPurchase >= 30) {
-                    return (
-                      <SingleItem
-                        key={index}
-                        {...doc.data()}
-                        id={doc.id}
-                        styles={styles.notSoSoon}
-                      />
-                    );
-                  } else {
-                    return (
-                      <SingleItem
-                        key={index}
-                        {...doc.data()}
-                        id={doc.id}
-                        styles={styles.inactive}
-                      />
-                    );
-                  }
-                })}
+                .map((doc, index) => (
+                  <SingleItem key={index} {...doc.data()} id={doc.id} />
+                ))}
             </>
           )}
         </>

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -86,7 +86,7 @@ const ItemsList = () => {
                     );
                   } else if (
                     doc.data().daysUntilPurchase > 7 &&
-                    doc.data().daysUntilPurchase <= 30
+                    doc.data().daysUntilPurchase < 30
                   ) {
                     return (
                       <SingleItem
@@ -96,7 +96,7 @@ const ItemsList = () => {
                         styles={styles.kindOfSoon}
                       />
                     );
-                  } else if (doc.data().daysUntilPurchase > 30) {
+                  } else if (doc.data().daysUntilPurchase >= 30) {
                     return (
                       <SingleItem
                         key={index}

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -20,14 +20,19 @@ const SingleItem = (props) => {
   );
 
   let bgColor;
+  let aria;
   if (daysPassedSincePurchase <= daysUntilPurchase) {
     bgColor = 'green';
+    aria = 'buy soon';
   } else if (daysPassedSincePurchase > 7 && daysPassedSincePurchase < 30) {
     bgColor = 'orange';
+    aria = 'buy kind of soon';
   } else if (daysPassedSincePurchase > 30 && daysPassedSincePurchase < 40) {
     bgColor = 'red';
+    aria = 'wait a while before buying';
   } else if (daysPassedSincePurchase >= 40) {
     bgColor = 'gray';
+    aria = "you haven't bought this in a long time";
   }
 
   const updateIsPurchased = async (id) => {
@@ -83,7 +88,7 @@ const SingleItem = (props) => {
 
   return (
     <div style={{ backgroundColor: bgColor }}>
-      <label htmlFor={name}>
+      <label htmlFor={name} aria-checked={isPurchased}>
         <input
           type="checkbox"
           id={name}

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -75,7 +75,7 @@ const SingleItem = (props) => {
           checked={isPurchased}
           onChange={handleChange}
         />
-        {name}
+        {name} - {daysUntilPurchase}
       </label>
     </div>
   );

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -15,10 +15,6 @@ const SingleItem = (props) => {
 
   const mlsPerDay = 24 * 60 * 60 * 1000;
 
-  // const daysPassedSincePurchase = Math.round(
-  //   (Date.now() - lastPurchasedDate) / mlsPerDay,
-  // );
-
   let bgColor;
   let aria;
   if (daysUntilPurchase <= 7) {

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -68,7 +68,7 @@ const SingleItem = (props) => {
   };
 
   return (
-    <div style={{ backgrundColor: styles }}>
+    <div style={{ backgroundColor: styles }}>
       <label htmlFor={name}>
         <input
           type="checkbox"

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -16,6 +16,22 @@ const SingleItem = (props) => {
 
   const mlsPerDay = 24 * 60 * 60 * 1000;
 
+  const daysPassedSincePurchase = Math.round(
+    (Date.now() - lastPurchasedDate) / mlsPerDay,
+  );
+
+  // let bgColor
+  // if(daysPassedSincePurchase <= 7) {
+  //   bgColor = 'green';
+  // } else if(daysPassedSincePurchase > 7 &&
+  // daysPassedSincePurchase < 30) {
+  //   bgColor = 'orange';
+  // } else if(daysPassedSincePurchase >= 30) {
+  //   bgColor = 'red';
+  // } else {
+  //   bgColor = 'gray';
+  // }
+
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).update({
       isPurchased: false,
@@ -68,7 +84,7 @@ const SingleItem = (props) => {
   };
 
   return (
-    <div style={{ backgrundColor: styles }}>
+    <div style={{ backgroundColor: styles }}>
       <label htmlFor={name}>
         <input
           type="checkbox"

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -11,7 +11,6 @@ const SingleItem = (props) => {
     lastPurchasedDate,
     numberOfPurchases,
     daysUntilPurchase,
-    styles,
   } = props;
 
   const mlsPerDay = 24 * 60 * 60 * 1000;
@@ -20,17 +19,16 @@ const SingleItem = (props) => {
     (Date.now() - lastPurchasedDate) / mlsPerDay,
   );
 
-  // let bgColor
-  // if(daysPassedSincePurchase <= 7) {
-  //   bgColor = 'green';
-  // } else if(daysPassedSincePurchase > 7 &&
-  // daysPassedSincePurchase < 30) {
-  //   bgColor = 'orange';
-  // } else if(daysPassedSincePurchase >= 30) {
-  //   bgColor = 'red';
-  // } else {
-  //   bgColor = 'gray';
-  // }
+  let bgColor;
+  if (daysPassedSincePurchase <= daysUntilPurchase) {
+    bgColor = 'green';
+  } else if (daysPassedSincePurchase > 7 && daysPassedSincePurchase < 30) {
+    bgColor = 'orange';
+  } else if (daysPassedSincePurchase > 30 && daysPassedSincePurchase < 40) {
+    bgColor = 'red';
+  } else if (daysPassedSincePurchase >= 40) {
+    bgColor = 'gray';
+  }
 
   const updateIsPurchased = async (id) => {
     await firestore.collection('items').doc(id).update({
@@ -84,7 +82,7 @@ const SingleItem = (props) => {
   };
 
   return (
-    <div style={{ backgroundColor: styles }}>
+    <div style={{ backgroundColor: bgColor }}>
       <label htmlFor={name}>
         <input
           type="checkbox"

--- a/src/components/SingleItem.js
+++ b/src/components/SingleItem.js
@@ -15,22 +15,22 @@ const SingleItem = (props) => {
 
   const mlsPerDay = 24 * 60 * 60 * 1000;
 
-  const daysPassedSincePurchase = Math.round(
-    (Date.now() - lastPurchasedDate) / mlsPerDay,
-  );
+  // const daysPassedSincePurchase = Math.round(
+  //   (Date.now() - lastPurchasedDate) / mlsPerDay,
+  // );
 
   let bgColor;
   let aria;
-  if (daysPassedSincePurchase <= daysUntilPurchase) {
+  if (daysUntilPurchase <= 7) {
     bgColor = 'green';
     aria = 'buy soon';
-  } else if (daysPassedSincePurchase > 7 && daysPassedSincePurchase < 30) {
+  } else if (daysUntilPurchase > 7 && daysUntilPurchase < 30) {
     bgColor = 'orange';
     aria = 'buy kind of soon';
-  } else if (daysPassedSincePurchase > 30 && daysPassedSincePurchase < 40) {
+  } else if (daysUntilPurchase > 30 && daysUntilPurchase < 40) {
     bgColor = 'red';
     aria = 'wait a while before buying';
-  } else if (daysPassedSincePurchase >= 40) {
+  } else {
     bgColor = 'gray';
     aria = "you haven't bought this in a long time";
   }
@@ -88,7 +88,7 @@ const SingleItem = (props) => {
 
   return (
     <div style={{ backgroundColor: bgColor }}>
-      <label htmlFor={name} aria-checked={isPurchased}>
+      <label htmlFor={name} aria-checked={isPurchased} aria-label={aria}>
         <input
           type="checkbox"
           id={name}

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,19 @@ code {
 .active-link {
   font-weight: bold;
 }
+
+.soon {
+  background-color: green;
+}
+
+.kindOfSoon {
+  background-color: orange;
+}
+
+.notSoSoon {
+  background-color: red;
+}
+
+.inactive {
+  background-color: gray;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,19 +25,3 @@ code {
 .active-link {
   font-weight: bold;
 }
-
-.soon {
-  background-color: green;
-}
-
-.kindOfSoon {
-  background-color: orange;
-}
-
-.notSoSoon {
-  background-color: red;
-}
-
-.inactive {
-  background-color: gray;
-}


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
- Sorted items list by estimated `daysUntilPurchase` 
👉 If an item's `daysUntilPurchase` are in the soon category (<= 7 days) it will be near the top, and colored in green
👉 If an item's `daysUntilPurchase` are in the kind of soon category ( between 7 - 30 days) it will be in the middle, and colored in orange
👉 If an item's `daysUntilPurchase` are in the not soon category (between 30 - 40 days) it will be near the bottom, and colored in red
👉 If an item's `daysUntilPurchase` are in the inactive category, it will be last in the list and have a background color of grey
- Also, sorted items list alphabetically by name, so items will first be sorted by `daysUntilPurchase`, and if that value is the same, they will be sorted alphabetically
- Added aria-label in the label tag in the `SingleItem` component, to allow the screen reader to make a distinction on how soon to buy the item.
- We also added an `aria-checked` attribute in the label tag to say if the checkbox is checked or not. If you hover over the element, it won't say if the checkbox is checked or not, but if you click on the element while inspecting the code, it will.
- In AddItem component, initialized `daysUntilPurchase` with `frequency` value so that it is not saved as null when first added to the database (see line 55 in AddItem component)
- NOTE: We tried various methods for properly calculating if an item is inactive or not. We tried calculating the number of days passed since the `lastPurchasedDate`, and saved that in a separate variable, but we were unable to properly integrate with our logic when comparing `daysUntilPurchase`, so we ended up just using an `else` statement instead
```
const daysPassedSincePurchase = Math.round((Date.now() - lastPurchasedDate) / mlsPerDay);
```
- NOTE: If an item is clicked/purchased, at least two times, it will move further up the list of items according to `daysUntilPurchase`. We had hoped/expected that it would still be alphabetical, but it is primarily sorted by `daysUntilPurchase`, and `name` second, so it won't always be alphabetically ordered

## Related Issue

closes #12 

## Acceptance Criteria

- Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- Items should be sorted by the estimated number of days until next purchase
- Items with the same number of estimated days until next purchase should be sorted alphabetically
- Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![sorted-collection](https://user-images.githubusercontent.com/56979810/129983885-df2366b6-0e4b-4edf-baf3-fab62b156c5e.JPG)

### After

Hover over elements to see accessibility attributes:
![Screenshot (8)](https://user-images.githubusercontent.com/56979810/129983784-d7da4ea2-77c0-4758-91b4-aaceaa037bdd.png)

Sorted Items with color:
![sorted-items](https://user-images.githubusercontent.com/56979810/129983863-df899b34-e09b-403b-9282-d167faf1acb5.JPG)

Enable voiceover on Mac:
<img width="669" alt="Screen Shot 2021-08-17 at 5 44 19 PM" src="https://user-images.githubusercontent.com/57311842/129986230-1e2ae7db-e4c1-4e20-9b5a-807a99b49b3b.png">


## Testing Steps / QA Criteria

- `git checkout hk-ia-sort-shopping-list`
- `git pull`
- `npm start`
- Add new items with varying frequencies
- Buy some of them to see how they are sorted
NOTE: the numbers next to the items' names represent `daysUntilPurchase` for that item

